### PR TITLE
fix: re-enable survey on extension (FYR-2554)

### DIFF
--- a/merlin_config.json
+++ b/merlin_config.json
@@ -1420,7 +1420,7 @@
     "visible": true
   },
   "survey": {
-    "visible": false,
+    "visible": true,
     "showSurveyInterval": 6,
     "questionnaire": [
       {


### PR DESCRIPTION
In the google sheet the Row Headers were missing which was causing the error. Added them back and it's dumping the data properly. Tested and working.