### PR TITLE
fix(merlin-config): enabled SERP in extension (MERLINP-307)

### DIFF
--- a/merlin_config.json
+++ b/merlin_config.json
@@ -1082,6 +1082,19 @@
         "#rhs"
       ]
     },
+    "dataCollection": {
+      "extension": {
+        "isActive": false,
+        "privacyPolicy": {
+          "serp": {
+            "visible": true
+          },
+          "chat": {
+            "visible": true
+          }
+        }
+      }
+    },
     "shouldDoStatusCall": false
   },
   "newUploadEndpoint": true,

--- a/merlin_config.json
+++ b/merlin_config.json
@@ -1070,7 +1070,7 @@
       },
       "newMount": true,
       "regional": false,
-      "visible": false,
+      "visible": true,
       "getHoroscope": {
         "text": "Discover your destiny with Merlin's horoscope predictions!",
         "isActive": false,


### PR DESCRIPTION
Changes:

- Enable SERP in extension
- We are primarily bringing in back SERP for data collection
- Data collection config for data logging and privacy policy ui popup